### PR TITLE
Bump dependencies and fix warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ language: csharp
 matrix:
   include:
     - os: linux
-      dist: bionic
+      dist: eoan
       mono: latest
-      dotnet: 2.2
+      dotnet: 3.1
 
 before_script:
 - git lfs install

--- a/build.cake
+++ b/build.cake
@@ -19,7 +19,7 @@
 // SOFTWARE.
 
 // NUnit tests
-#tool nuget:?package=NUnit.ConsoleRunner&version=3.9.0
+#tool nuget:?package=NUnit.ConsoleRunner&version=3.11.1
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");
@@ -34,10 +34,10 @@ string solutionPath = "src/Lemon.sln";
 string netstandardVersion = "2.0";
 string netstandardBinDir = $"bin/{configuration}/netstandard{netstandardVersion}";
 
-string netVersion = "472";
+string netVersion = "48";
 string netBinDir = $"bin/{configuration}/net{netVersion}";
 
-string netcoreVersion = "2.2";
+string netcoreVersion = "3.1";
 string netcoreBinDir = $"bin/{configuration}/netcoreapp{netcoreVersion}";
 
 Task("Clean")

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="Yarhl Alpha" value="https://pkgs.dev.azure.com/SceneGate/Yarhl/_packaging/preview%40Local/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/omnisharp.json
+++ b/omnisharp.json
@@ -1,0 +1,8 @@
+{
+  "fileOptions": {
+      "excludeSearchPatterns": [
+        "**/bin/**/*",
+        "**/obj/**/*"
+      ]
+  }
+}

--- a/src/Lemon.IntegrationTests/Containers/ExeFsConverterTests.cs
+++ b/src/Lemon.IntegrationTests/Containers/ExeFsConverterTests.cs
@@ -85,11 +85,9 @@ namespace Lemon.IntegrationTests.Containers
                     () => node.TransformWith<BinaryExeFs2NodeContainer>(),
                     Throws.Nothing);
                 Assert.That(logger.IsEmpty, Is.True);
-
+            } finally {
                 node.Dispose();
                 Assert.That(DataStream.ActiveStreams, Is.EqualTo(0));
-            }
-            catch {
             }
         }
 
@@ -98,7 +96,7 @@ namespace Lemon.IntegrationTests.Containers
         {
             string yaml = File.ReadAllText(yamlPath);
             NodeContainerInfo expected = new DeserializerBuilder()
-                .WithNamingConvention(new UnderscoredNamingConvention())
+                .WithNamingConvention(UnderscoredNamingConvention.Instance)
                 .Build()
                 .Deserialize<NodeContainerInfo>(yaml);
 

--- a/src/Lemon.IntegrationTests/Containers/IvfcConverterTests.cs
+++ b/src/Lemon.IntegrationTests/Containers/IvfcConverterTests.cs
@@ -85,11 +85,9 @@ namespace Lemon.IntegrationTests.Containers
                     () => node.TransformWith<BinaryIvfc2NodeContainer>(),
                     Throws.Nothing);
                 Assert.That(logger.IsEmpty, Is.True);
-
+            } finally {
                 node.Dispose();
                 Assert.That(DataStream.ActiveStreams, Is.EqualTo(0));
-            }
-            catch {
             }
         }
 
@@ -98,7 +96,7 @@ namespace Lemon.IntegrationTests.Containers
         {
             string yaml = File.ReadAllText(yamlPath);
             NodeContainerInfo expected = new DeserializerBuilder()
-                .WithNamingConvention(new UnderscoredNamingConvention())
+                .WithNamingConvention(UnderscoredNamingConvention.Instance)
                 .Build()
                 .Deserialize<NodeContainerInfo>(yaml);
 

--- a/src/Lemon.IntegrationTests/Containers/NcchConverterTests.cs
+++ b/src/Lemon.IntegrationTests/Containers/NcchConverterTests.cs
@@ -63,7 +63,7 @@ namespace Lemon.IntegrationTests.Containers
 
             string yaml = File.ReadAllText(yamlPath);
             expected = new DeserializerBuilder()
-                .WithNamingConvention(new UnderscoredNamingConvention())
+                .WithNamingConvention(UnderscoredNamingConvention.Instance)
                 .Build()
                 .Deserialize<NcchTestInfo>(yaml);
         }

--- a/src/Lemon.IntegrationTests/Containers/NcsdConverterTests.cs
+++ b/src/Lemon.IntegrationTests/Containers/NcsdConverterTests.cs
@@ -57,7 +57,7 @@ namespace Lemon.IntegrationTests.Containers
 
             string yaml = File.ReadAllText(yamlPath);
             expected = new DeserializerBuilder()
-                .WithNamingConvention(new UnderscoredNamingConvention())
+                .WithNamingConvention(UnderscoredNamingConvention.Instance)
                 .Build()
                 .Deserialize<NcsdTestInfo>(yaml);
         }

--- a/src/Lemon.IntegrationTests/Containers/TestData.cs
+++ b/src/Lemon.IntegrationTests/Containers/TestData.cs
@@ -19,13 +19,12 @@
 // SOFTWARE.
 namespace Lemon.IntegrationTests.Containers
 {
-    using System;
     using System.Collections;
     using System.IO;
     using System.Linq;
     using NUnit.Framework;
 
-    public class TestData
+    public static class TestData
     {
         public static string ContainersResources {
             get {

--- a/src/Lemon.IntegrationTests/Lemon.IntegrationTests.csproj
+++ b/src/Lemon.IntegrationTests/Lemon.IntegrationTests.csproj
@@ -14,17 +14,17 @@
     <License>MIT</License>
     <IsPackable>false</IsPackable>
 
-    <TargetFrameworks>netcoreapp2.2;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <RootNamespace>Lemon.IntegrationTests</RootNamespace>
     <CodeAnalysisRuleSet>..\StyleCop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="YamlDotNet" Version="6.0.0" />
+    <PackageReference Include="YamlDotNet" Version="8.1.0" />
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" >
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" >
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Lemon/Containers/Converters/Binary2Ncch.cs
+++ b/src/Lemon/Containers/Converters/Binary2Ncch.cs
@@ -20,6 +20,7 @@
 namespace Lemon.Containers.Converters
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using Lemon.Containers.Formats;
     using Yarhl.FileFormat;
     using Yarhl.FileSystem;
@@ -65,6 +66,7 @@ namespace Lemon.Containers.Converters
             return ncch;
         }
 
+        [SuppressMessage("Reliability", "CA2000", Justification = "Transfer ownership")]
         static void AddChildIfExists(string name, Node root, DataReader reader)
         {
             BinaryFormat binary = ReadBinaryChild(reader);

--- a/src/Lemon/Containers/Converters/Binary2Ncsd.cs
+++ b/src/Lemon/Containers/Converters/Binary2Ncsd.cs
@@ -20,6 +20,7 @@
 namespace Lemon.Containers.Converters
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using Lemon.Containers.Formats;
     using Yarhl.FileFormat;
@@ -59,6 +60,7 @@ namespace Lemon.Containers.Converters
         /// </summary>
         /// <param name="source">Binary stream to convert.</param>
         /// <returns>The new NCSD instance.</returns>
+        [SuppressMessage("Reliability", "CA2000", Justification = "Transfer ownership")]
         public Ncsd Convert(BinaryFormat source)
         {
             if (source == null)

--- a/src/Lemon/Containers/Converters/BinaryExeFs2NodeContainer.cs
+++ b/src/Lemon/Containers/Converters/BinaryExeFs2NodeContainer.cs
@@ -20,6 +20,7 @@
 namespace Lemon.Containers.Converters
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Security.Cryptography;
     using System.Text;
@@ -47,6 +48,7 @@ namespace Lemon.Containers.Converters
         /// </summary>
         /// <param name="source">The binary stream to convert.</param>
         /// <returns>The file system from the ExeFS stream.</returns>
+        [SuppressMessage("Reliability", "CA2000", Justification = "Transfer ownership")]
         public NodeContainerFormat Convert(BinaryFormat source)
         {
             if (source == null)
@@ -138,6 +140,7 @@ namespace Lemon.Containers.Converters
             return binary;
         }
 
+        [SuppressMessage("Reliability", "CA2000", Justification = "Transfer ownership")]
         static Node GetNodeFromHeader(DataReader reader)
         {
             string name = reader.ReadString(8).Replace("\0", string.Empty);

--- a/src/Lemon/Containers/Converters/BinaryIvfc2NodeContainer.cs
+++ b/src/Lemon/Containers/Converters/BinaryIvfc2NodeContainer.cs
@@ -20,6 +20,7 @@
 namespace Lemon.Containers.Converters
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Text;
     using Lemon.Logging;
     using Yarhl.FileFormat;
@@ -120,6 +121,7 @@ namespace Lemon.Containers.Converters
             return root;
         }
 
+        [SuppressMessage("Reliability", "CA2000", Justification = "Transfer ownership")]
         void ReadDirectoryInfo(Node parent)
         {
             levelReader.Stream.Position += 4; // no need parent directory

--- a/src/Lemon/Containers/Converters/Ivfc/FileSystemWriter.cs
+++ b/src/Lemon/Containers/Converters/Ivfc/FileSystemWriter.cs
@@ -176,10 +176,10 @@ namespace Lemon.Containers.Converters.Ivfc
 
         void WriteNode(Node current, uint currentOffset)
         {
-            var files = current.Children.Where(n => !n.IsContainer).ToList();
-            for (int i = 0; i < files.Count; i++)
+            var subFiles = current.Children.Where(n => !n.IsContainer).ToList();
+            for (int i = 0; i < subFiles.Count; i++)
             {
-                WriteFileInfo(files[i], i == 0, i + 1 == files.Count, currentOffset);
+                WriteFileInfo(subFiles[i], i == 0, i + 1 == subFiles.Count, currentOffset);
             }
 
             var dirs = current.Children.Where(n => n.IsContainer).ToList();

--- a/src/Lemon/Containers/Converters/Ivfc/LevelStream.cs
+++ b/src/Lemon/Containers/Converters/Ivfc/LevelStream.cs
@@ -153,9 +153,27 @@ namespace Lemon.Containers.Converters.Ivfc
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Releases all resources used by the object.
+        /// </summary>
+        /// <param name="freeManaged">Whethever to free the managed resources too.</param>
+        protected virtual void Dispose(bool freeManaged)
+        {
+            if (Disposed) {
+                return;
+            }
+
+            Disposed = true;
+            if (freeManaged) {
+                sha.Dispose();
+                if (managedStream) {
+                    stream.Dispose();
+                }
+            }
+        }
+
         void WriteAndUpdateHash(byte[] data, int offset, int count)
         {
-            byte[] empty = Array.Empty<byte>();
             while (true) {
                 // Repeat until writing the data does not span into the next block.
                 long writtenBlocks = Position / BlockSize;
@@ -206,18 +224,6 @@ namespace Lemon.Containers.Converters.Ivfc
             stream.Position = Position;
             Position += count;
             stream.Write(data, index, count);
-        }
-
-        void Dispose(bool freeManaged)
-        {
-            if (Disposed) {
-                return;
-            }
-
-            Disposed = true;
-            if (freeManaged && managedStream) {
-                stream.Dispose();
-            }
         }
     }
 }

--- a/src/Lemon/Containers/Converters/NodeContainer2BinaryIvfc.cs
+++ b/src/Lemon/Containers/Converters/NodeContainer2BinaryIvfc.cs
@@ -73,10 +73,10 @@ namespace Lemon.Containers.Converters
         /// <summary>
         /// Initialize the converter by providing the stream to write to.
         /// </summary>
-        /// <param name="stream">Stream to write to.</param>
-        public void Initialize(DataStream stream)
+        /// <param name="parameters">Stream to write to.</param>
+        public void Initialize(DataStream parameters)
         {
-            this.stream = stream;
+            this.stream = parameters;
         }
 
         /// <summary>
@@ -122,13 +122,13 @@ namespace Lemon.Containers.Converters
             binary.Stream.Length += level3Padded;
 
             // Create "special" data streams that will create hashes on-the-fly.
-            var level1 = new LevelStream(BlockSize);
-            var level2 = new LevelStream(BlockSize);
-            var level3 = new LevelStream(BlockSize, binary.Stream.BaseStream);
+            using (var level1 = new LevelStream(BlockSize))
+            using (var level2 = new LevelStream(BlockSize))
+            using (var level3 = new LevelStream(BlockSize, binary.Stream.BaseStream))
             using (var level0Stream = new DataStream(binary.Stream, level0DataOffset, levelSizes[0]))
             using (var level1Stream = new DataStream(level1))
             using (var level2Stream = new DataStream(level2))
-            using (var level3Stream = new DataStream(level3, level3Offset, level3Padded)) {
+            using (var level3Stream = new DataStream(level3, level3Offset, level3Padded, true)) {
                 level3.BlockWritten += (_, e) => level2Stream.Write(e.Hash, 0, e.Hash.Length);
                 level2.BlockWritten += (_, e) => level1Stream.Write(e.Hash, 0, e.Hash.Length);
                 level1.BlockWritten += (_, e) => level0Stream.Write(e.Hash, 0, e.Hash.Length);

--- a/src/Lemon/Lemon.csproj
+++ b/src/Lemon/Lemon.csproj
@@ -23,27 +23,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibLog" Version="5.0.6">
+    <PackageReference Include="LibLog" Version="5.0.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Yarhl" Version="3.0.0-alpha07" />
-    <PackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.9.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.6.0.16497" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Text.Analyzers" Version="2.6.4">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Yarhl" Version="3.0.0-alpha10" />
   </ItemGroup>
 
 </Project>

--- a/src/StyleCop.ruleset
+++ b/src/StyleCop.ruleset
@@ -19,5 +19,11 @@
 
     <!-- Allow initializer to have brace in the same line. -->
     <Rule Id="SA1137" Action="None" />
+
+    <!-- Allow hard-coding English exception messages -->
+    <Rule Id="CA1303" Action="None" />
+
+    <!-- Allow TODO messages -->
+    <Rule Id="S1135" Action="None" />
   </Rules>
 </RuleSet>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.32.1" />
+    <package id="Cake" version="0.37.0" />
 </packages>


### PR DESCRIPTION
Run the tests against .NET Core 3.1 LTS and update dependencies to their latest stable release. This fix the builds with Cake and the latest version of mono.