### PR TITLE
Implement CIA unpacker and TMD deserializer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,9 @@
 {
-    "dotnet-test-explorer.testProjectPath": "src/Lemon.IntegrationTests/Lemon.IntegrationTests.csproj"
+    "dotnet-test-explorer.testProjectPath": "src/Lemon.IntegrationTests/Lemon.IntegrationTests.csproj",
+    "cSpell.words": [
+        "IVFC",
+        "NAND",
+        "NCCH",
+        "NCSD"
+    ]
 }

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # Lemon [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://choosealicense.com/licenses/mit/) [![Build Status](https://travis-ci.org/SceneGate/Lemon.svg?branch=master)](https://travis-ci.org/SceneGate/Lemon)
 
-[Yarhl](https://github.com/SceneGate/yarhl) plugin for Nintendo 3DS common formats.
+[Yarhl](https://github.com/SceneGate/yarhl) plugin for Nintendo 3DS common
+formats.
 
 ## Supported formats
 
-* **NCSD (CCI and CSU)**: unpack
-* **NCCH (CXI and CFA)**: unpack
-* **ExeFS**: unpack and pack (*full support*)
-* **RomFS**: unpack and pack (*full support*)
+_Encryption or signature validation not supported yet._
+
+- **NCSD (CCI and CSU)**: unpack
+- **CIA**: unpack
+- **NCCH (CXI and CFA)**: unpack
+- **ExeFS**: unpack and pack
+- **RomFS**: unpack and pack
+- **TMD**: deserialize

--- a/src/Lemon.IntegrationTests/Containers/Binary2ContainerTests.cs
+++ b/src/Lemon.IntegrationTests/Containers/Binary2ContainerTests.cs
@@ -86,7 +86,7 @@ namespace Lemon.IntegrationTests.Containers
         public void TransformBothWays()
         {
             if (binaryConverter == null) {
-                Assert.Ignore("Not implemented");
+                Assert.Ignore();
             }
 
             using var nodes = containerConverter.Convert(original);

--- a/src/Lemon.IntegrationTests/Containers/Binary2ContainerTests.cs
+++ b/src/Lemon.IntegrationTests/Containers/Binary2ContainerTests.cs
@@ -1,0 +1,135 @@
+// Copyright (c) 2019 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Lemon.IntegrationTests.Containers
+{
+    using Lemon.Logging;
+    using NUnit.Framework;
+    using Yarhl.FileFormat;
+    using Yarhl.FileSystem;
+    using Yarhl.IO;
+
+    public abstract class Binary2ContainerTests
+    {
+        readonly CaptureLogger logger;
+        int initialStreams;
+        BinaryFormat original;
+        NodeContainerInfo containerInfo;
+        IConverter<BinaryFormat, NodeContainerFormat> containerConverter;
+        IConverter<NodeContainerFormat, BinaryFormat> binaryConverter;
+
+        protected Binary2ContainerTests()
+        {
+            logger = new CaptureLogger();
+            LogProvider.SetCurrentLogProvider(logger);
+        }
+
+        [OneTimeSetUp]
+        public void SetUpFixture()
+        {
+            containerInfo = GetContainerInfo();
+            containerConverter = GetToContainerConverter();
+            binaryConverter = GetToBinaryConverter();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            original?.Dispose();
+
+            // Make sure we didn't leave anything without dispose.
+            Assert.That(DataStream.ActiveStreams, Is.EqualTo(initialStreams));
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            logger.Clear();
+
+            // By opening and disposing in each we prevent other tests failing
+            // because the file is still open.
+            initialStreams = DataStream.ActiveStreams;
+            original = GetBinary();
+        }
+
+        [Test]
+        public void TransformToContainer()
+        {
+            int initialStreams = DataStream.ActiveStreams;
+
+            // Check nodes are expected
+            using var nodes = containerConverter.Convert(original);
+            CheckNode(containerInfo, nodes.Root);
+
+            // Check everything is virtual node
+            Assert.That(DataStream.ActiveStreams, Is.EqualTo(initialStreams));
+            Assert.That(logger.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void TransformBothWays()
+        {
+            if (binaryConverter == null) {
+                Assert.Ignore("Not implemented");
+            }
+
+            using var nodes = containerConverter.Convert(original);
+            using var actualBinary = binaryConverter.Convert(nodes);
+
+            Assert.That(original.Stream.Compare(actualBinary.Stream), Is.True);
+        }
+
+        protected abstract BinaryFormat GetBinary();
+
+        protected abstract NodeContainerInfo GetContainerInfo();
+
+        protected abstract IConverter<BinaryFormat, NodeContainerFormat> GetToContainerConverter();
+
+        protected abstract IConverter<NodeContainerFormat, BinaryFormat> GetToBinaryConverter();
+
+        private static void CheckNode(NodeContainerInfo info, Node node)
+        {
+            TestContext.WriteLine(node.Path);
+            Assert.That(node.Name, Is.EqualTo(info.Name));
+            Assert.That(node.Format?.GetType().FullName, Is.EqualTo(info.FormatType));
+
+            if (info.Tags != null) {
+                // YAML deserializer always gets the value as a string
+                foreach (var entry in info.Tags) {
+                    Assert.That(node.Tags.ContainsKey(entry.Key), Is.True);
+                    Assert.That(node.Tags[entry.Key].ToString(), Is.EqualTo(entry.Value));
+                }
+            }
+
+            if (info.StreamLength > 0) {
+                Assert.That(node.Stream.Offset, Is.EqualTo(info.StreamOffset));
+                Assert.That(node.Stream.Length, Is.EqualTo(info.StreamLength));
+            }
+
+            if (info.CheckChildren) {
+                int expectedCount = info.Children?.Count ?? 0;
+                Assert.That(expectedCount, Is.EqualTo(node.Children.Count));
+
+                for (int i = 0; i < expectedCount; i++) {
+                    CheckNode(info.Children[i], node.Children[i]);
+                }
+            }
+        }
+    }
+}

--- a/src/Lemon.IntegrationTests/Containers/CiaConverterTests.cs
+++ b/src/Lemon.IntegrationTests/Containers/CiaConverterTests.cs
@@ -19,26 +19,23 @@
 // SOFTWARE.
 namespace Lemon.IntegrationTests.Containers
 {
+    using System.IO;
     using Lemon.Containers.Converters;
     using NUnit.Framework;
     using Yarhl.FileFormat;
     using Yarhl.FileSystem;
     using Yarhl.IO;
 
-    [TestFixtureSource(typeof(TestData), nameof(TestData.ExeFsParams))]
-    public class ExeFsConverterTests : Binary2ContainerTests
+    [TestFixtureSource(typeof(TestData), nameof(TestData.CiaParams))]
+    public class CiaConverterTests : Binary2ContainerTests
     {
         readonly string yamlPath;
         readonly string binaryPath;
-        readonly int offset;
-        readonly int size;
 
-        public ExeFsConverterTests(string yamlPath, string binaryPath, int offset, int size)
+        public CiaConverterTests(string yamlPath, string binaryPath)
         {
             this.yamlPath = yamlPath;
             this.binaryPath = binaryPath;
-            this.offset = offset;
-            this.size = size;
 
             TestDataBase.IgnoreIfFileDoesNotExist(binaryPath);
             TestDataBase.IgnoreIfFileDoesNotExist(yamlPath);
@@ -46,8 +43,8 @@ namespace Lemon.IntegrationTests.Containers
 
         protected override BinaryFormat GetBinary()
         {
-            TestContext.WriteLine(binaryPath);
-            var stream = DataStreamFactory.FromFile(binaryPath, FileOpenMode.Read, offset, size);
+            TestContext.WriteLine(Path.GetFileName(binaryPath));
+            var stream = DataStreamFactory.FromFile(binaryPath, FileOpenMode.Read);
             return new BinaryFormat(stream);
         }
 
@@ -58,12 +55,12 @@ namespace Lemon.IntegrationTests.Containers
 
         protected override IConverter<BinaryFormat, NodeContainerFormat> GetToContainerConverter()
         {
-            return new BinaryExeFs2NodeContainer();
+            return new BinaryCia2NodeContainer();
         }
 
         protected override IConverter<NodeContainerFormat, BinaryFormat> GetToBinaryConverter()
         {
-            return new BinaryExeFs2NodeContainer();
+            return null;
         }
     }
 }

--- a/src/Lemon.IntegrationTests/Containers/CiaConverterTests.cs
+++ b/src/Lemon.IntegrationTests/Containers/CiaConverterTests.cs
@@ -60,6 +60,7 @@ namespace Lemon.IntegrationTests.Containers
 
         protected override IConverter<NodeContainerFormat, BinaryFormat> GetToBinaryConverter()
         {
+            TestContext.Progress.WriteLine("Binary converter for CIA not implemented");
             return null;
         }
     }

--- a/src/Lemon.IntegrationTests/Containers/ExeFsConverterTests.cs
+++ b/src/Lemon.IntegrationTests/Containers/ExeFsConverterTests.cs
@@ -52,10 +52,8 @@ namespace Lemon.IntegrationTests.Containers
         [OneTimeSetUp]
         public void SetUpFixture()
         {
-            if (!File.Exists(binaryPath))
-                Assert.Ignore($"Binary file doesn't exist: {binaryPath}");
-            if (!File.Exists(yamlPath))
-                Assert.Ignore($"YAML file doesn't exist: {yamlPath}");
+            TestDataBase.IgnoreIfFileDoesNotExist(binaryPath);
+            TestDataBase.IgnoreIfFileDoesNotExist(yamlPath);
 
             logger = new CaptureLogger();
             LogProvider.SetCurrentLogProvider(logger);

--- a/src/Lemon.IntegrationTests/Containers/IvfcConverterTests.cs
+++ b/src/Lemon.IntegrationTests/Containers/IvfcConverterTests.cs
@@ -52,10 +52,8 @@ namespace Lemon.IntegrationTests.Containers
         [OneTimeSetUp]
         public void SetUpFixture()
         {
-            if (!File.Exists(binaryPath))
-                Assert.Ignore($"Binary file doesn't exist: {binaryPath}");
-            if (!File.Exists(yamlPath))
-                Assert.Ignore($"YAML file doesn't exist: {yamlPath}");
+            TestDataBase.IgnoreIfFileDoesNotExist(binaryPath);
+            TestDataBase.IgnoreIfFileDoesNotExist(yamlPath);
 
             logger = new CaptureLogger();
             LogProvider.SetCurrentLogProvider(logger);

--- a/src/Lemon.IntegrationTests/Containers/IvfcConverterTests.cs
+++ b/src/Lemon.IntegrationTests/Containers/IvfcConverterTests.cs
@@ -19,27 +19,19 @@
 // SOFTWARE.
 namespace Lemon.IntegrationTests.Containers
 {
-    using System;
-    using System.IO;
     using Lemon.Containers.Converters;
-    using Lemon.Logging;
     using NUnit.Framework;
-    using YamlDotNet.Serialization;
-    using YamlDotNet.Serialization.NamingConventions;
     using Yarhl.FileFormat;
     using Yarhl.FileSystem;
     using Yarhl.IO;
 
     [TestFixtureSource(typeof(TestData), nameof(TestData.IvfcParams))]
-    public class IvfcConverterTests
+    public class IvfcConverterTests : Binary2ContainerTests
     {
         readonly string yamlPath;
         readonly string binaryPath;
         readonly int offset;
         readonly int size;
-
-        CaptureLogger logger;
-        Node node;
 
         public IvfcConverterTests(string yamlPath, string binaryPath, int offset, int size)
         {
@@ -47,146 +39,31 @@ namespace Lemon.IntegrationTests.Containers
             this.binaryPath = binaryPath;
             this.offset = offset;
             this.size = size;
-        }
 
-        [OneTimeSetUp]
-        public void SetUpFixture()
-        {
             TestDataBase.IgnoreIfFileDoesNotExist(binaryPath);
             TestDataBase.IgnoreIfFileDoesNotExist(yamlPath);
-
-            logger = new CaptureLogger();
-            LogProvider.SetCurrentLogProvider(logger);
         }
 
-        [SetUp]
-        public void SetUp()
+        protected override BinaryFormat GetBinary()
         {
-            logger.Clear();
-
-            Console.WriteLine(Path.GetFileName(binaryPath));
+            TestContext.WriteLine(binaryPath);
             var stream = DataStreamFactory.FromFile(binaryPath, FileOpenMode.Read, offset, size);
-            node = new Node("rom", new BinaryFormat(stream));
+            return new BinaryFormat(stream);
         }
 
-        [TearDown]
-        public void TearDownFixture()
+        protected override NodeContainerInfo GetContainerInfo()
         {
-            node?.Dispose();
+            return NodeContainerInfo.FromYaml(yamlPath);
         }
 
-        [Test]
-        public void TransformToContainer()
+        protected override IConverter<BinaryFormat, NodeContainerFormat> GetToContainerConverter()
         {
-            try {
-                Assert.That(
-                    () => node.TransformWith<BinaryIvfc2NodeContainer>(),
-                    Throws.Nothing);
-                Assert.That(logger.IsEmpty, Is.True);
-            } finally {
-                node.Dispose();
-                Assert.That(DataStream.ActiveStreams, Is.EqualTo(0));
-            }
+            return new BinaryIvfc2NodeContainer();
         }
 
-        [Test]
-        public void ValidateNodes()
+        protected override IConverter<NodeContainerFormat, BinaryFormat> GetToBinaryConverter()
         {
-            string yaml = File.ReadAllText(yamlPath);
-            NodeContainerInfo expected = new DeserializerBuilder()
-                .WithNamingConvention(UnderscoredNamingConvention.Instance)
-                .Build()
-                .Deserialize<NodeContainerInfo>(yaml);
-
-            node.TransformWith<BinaryIvfc2NodeContainer>();
-            CheckNode(expected, node);
-        }
-
-        [Test]
-        public void TransformBothWays()
-        {
-            BinaryFormat expected = null;
-            NodeContainerFormat content = null;
-            BinaryFormat actual = null;
-            try {
-                expected = node.GetFormatAs<BinaryFormat>();
-                content = (NodeContainerFormat)ConvertFormat
-                    .With<BinaryIvfc2NodeContainer>(expected);
-
-                Assert.That(
-                    () => actual = (BinaryFormat)ConvertFormat
-                        .With<NodeContainer2BinaryIvfc>(content),
-                    Throws.Nothing);
-                Assert.That(logger.IsEmpty, Is.True);
-
-                Assert.That(expected.Stream.Compare(actual.Stream), Is.True);
-            } finally {
-                expected?.Dispose();
-                content?.Dispose();
-                actual?.Dispose();
-                node.Dispose();
-                Assert.That(DataStream.ActiveStreams, Is.EqualTo(0));
-            }
-        }
-
-        [Test]
-        public void TransformBotnWaysInChildren()
-        {
-            DataStream expected = null;
-            DataStream actual = null;
-            try {
-                expected = new DataStream(node.Stream, 0, node.Stream.Length);
-
-                Node parent = new Node("program");
-                parent.Add(node);
-
-                actual = parent.Children["rom"]
-                    .TransformWith<BinaryIvfc2NodeContainer>()
-                    .TransformWith<NodeContainer2BinaryIvfc>()
-                    .Stream;
-
-                Assert.That(logger.IsEmpty, Is.True);
-                Assert.That(expected.Compare(actual), Is.True);
-            } finally {
-                expected.Dispose();
-                node.Dispose();
-                Assert.That(DataStream.ActiveStreams, Is.EqualTo(0));
-            }
-        }
-
-        public void CheckNode(NodeContainerInfo expected, Node actual)
-        {
-            Assert.That(
-                actual.Name,
-                Is.EqualTo(expected.Name),
-                actual.Path);
-
-            Assert.That(
-                actual.Format.GetType().FullName,
-                Is.EqualTo(expected.FormatType),
-                actual.Path);
-
-            if (actual.Stream != null) {
-                Assert.That(
-                    actual.Stream.Offset,
-                    Is.EqualTo(expected.StreamOffset),
-                    actual.Path);
-                Assert.That(
-                    actual.Stream.Length,
-                    Is.EqualTo(expected.StreamLength),
-                    actual.Path);
-            }
-
-            if (expected.CheckChildren) {
-                Assert.That(
-                    expected.Children?.Count ?? 0,
-                    Is.EqualTo(actual.Children.Count),
-                    actual.Path);
-
-                for (int i = 0; i < actual.Children.Count; i++) {
-                    CheckNode(expected.Children[i], actual.Children[i]);
-                }
-            }
+            return new NodeContainer2BinaryIvfc();
         }
     }
 }

--- a/src/Lemon.IntegrationTests/Containers/NcchConverterTests.cs
+++ b/src/Lemon.IntegrationTests/Containers/NcchConverterTests.cs
@@ -50,10 +50,8 @@ namespace Lemon.IntegrationTests.Containers
         [OneTimeSetUp]
         public void SetUpFixture()
         {
-            if (!File.Exists(binaryPath))
-                Assert.Ignore($"Binary file doesn't exist: {binaryPath}");
-            if (!File.Exists(yamlPath))
-                Assert.Ignore($"YAML file doesn't exist: {yamlPath}");
+            TestDataBase.IgnoreIfFileDoesNotExist(binaryPath);
+            TestDataBase.IgnoreIfFileDoesNotExist(yamlPath);
 
             var stream = DataStreamFactory.FromFile(binaryPath, FileOpenMode.Read, offset, size);
             actualNode = new Node("actual", new BinaryFormat(stream));

--- a/src/Lemon.IntegrationTests/Containers/NcsdConverterTests.cs
+++ b/src/Lemon.IntegrationTests/Containers/NcsdConverterTests.cs
@@ -46,10 +46,8 @@ namespace Lemon.IntegrationTests.Containers
         [OneTimeSetUp]
         public void SetUpFixture()
         {
-            if (!File.Exists(ncsdPath))
-                Assert.Ignore($"NCSD file doesn't exist: {ncsdPath}");
-            if (!File.Exists(yamlPath))
-                Assert.Ignore($"YAML file doesn't exist: {yamlPath}");
+            TestDataBase.IgnoreIfFileDoesNotExist(ncsdPath);
+            TestDataBase.IgnoreIfFileDoesNotExist(yamlPath);
 
             actualNode = NodeFactory.FromFile(ncsdPath);
             Assert.That(() => actualNode.TransformTo<Ncsd>(), Throws.Nothing);

--- a/src/Lemon.IntegrationTests/Containers/NodeContainerInfo.cs
+++ b/src/Lemon.IntegrationTests/Containers/NodeContainerInfo.cs
@@ -20,6 +20,10 @@
 namespace Lemon.IntegrationTests.Containers
 {
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.IO;
+    using YamlDotNet.Serialization;
+    using YamlDotNet.Serialization.NamingConventions;
 
     public class NodeContainerInfo
     {
@@ -31,8 +35,19 @@ namespace Lemon.IntegrationTests.Containers
 
         public long StreamLength { get; set; }
 
+        public Dictionary<string, object> Tags { get; set; }
+
         public bool CheckChildren { get; set; }
 
-        public List<NodeContainerInfo> Children { get; set; }
+        public Collection<NodeContainerInfo> Children { get; set; }
+
+        public static NodeContainerInfo FromYaml(string path)
+        {
+            string yaml = File.ReadAllText(path);
+            return new DeserializerBuilder()
+                .WithNamingConvention(UnderscoredNamingConvention.Instance)
+                .Build()
+                .Deserialize<NodeContainerInfo>(yaml);
+        }
     }
 }

--- a/src/Lemon.IntegrationTests/Containers/TestData.cs
+++ b/src/Lemon.IntegrationTests/Containers/TestData.cs
@@ -26,56 +26,48 @@ namespace Lemon.IntegrationTests.Containers
 
     public static class TestData
     {
-        public static string ContainersResources {
-            get {
-                return Path.Combine(TestDataBase.RootFromOutputPath, "containers");
-            }
+        public static IEnumerable NcsdParams {
+            get => GetStreamAndInfoCollection("ncsd.txt");
         }
 
-        public static IEnumerable NcsdParams {
-            get {
-                return TestDataBase.ReadTestListFile(Path.Combine(ContainersResources, "ncsd.txt"))
+        public static IEnumerable CiaParams {
+            get => GetStreamAndInfoCollection("cia.txt");
+        }
+
+        public static IEnumerable NcchParams {
+            get => GetSubstreamAndInfoCollection("ncch.txt");
+        }
+
+        public static IEnumerable ExeFsParams {
+            get => GetSubstreamAndInfoCollection("exefs.txt");
+        }
+
+        public static IEnumerable IvfcParams {
+            get => GetSubstreamAndInfoCollection("ivfc.txt");
+        }
+
+        private static string ContainersResources {
+            get => Path.Combine(TestDataBase.RootFromOutputPath, "containers");
+        }
+
+        private static IEnumerable GetStreamAndInfoCollection(string listName)
+        {
+            return TestDataBase.ReadTestListFile(Path.Combine(ContainersResources, listName))
                     .Select(line => line.Split(','))
                     .Select(data => new TestFixtureData(
                         Path.Combine(ContainersResources, data[0]),
                         Path.Combine(ContainersResources, data[1])));
-            }
         }
 
-        public static IEnumerable NcchParams {
-            get {
-                return TestDataBase.ReadTestListFile(Path.Combine(ContainersResources, "ncch.txt"))
+        private static IEnumerable GetSubstreamAndInfoCollection(string listName)
+        {
+            return TestDataBase.ReadTestListFile(Path.Combine(ContainersResources, listName))
                     .Select(line => line.Split(','))
                     .Select(data => new TestFixtureData(
                         Path.Combine(ContainersResources, data[0]),
                         Path.Combine(ContainersResources, data[1]),
                         int.Parse(data[2]),
                         int.Parse(data[3])));
-            }
-        }
-
-        public static IEnumerable ExeFsParams {
-            get {
-                return TestDataBase.ReadTestListFile(Path.Combine(ContainersResources, "exefs.txt"))
-                    .Select(line => line.Split(','))
-                    .Select(data => new TestFixtureData(
-                        Path.Combine(ContainersResources, data[0]),
-                        Path.Combine(ContainersResources, data[1]),
-                        int.Parse(data[2]),
-                        int.Parse(data[3])));
-            }
-        }
-
-        public static IEnumerable IvfcParams {
-            get {
-                return TestDataBase.ReadTestListFile(Path.Combine(ContainersResources, "ivfc.txt"))
-                    .Select(line => line.Split(','))
-                    .Select(data => new TestFixtureData(
-                        Path.Combine(ContainersResources, data[0]),
-                        Path.Combine(ContainersResources, data[1]),
-                        int.Parse(data[2]),
-                        int.Parse(data[3])));
-            }
         }
     }
 }

--- a/src/Lemon.IntegrationTests/Lemon.IntegrationTests.csproj
+++ b/src/Lemon.IntegrationTests/Lemon.IntegrationTests.csproj
@@ -14,17 +14,18 @@
     <License>MIT</License>
     <IsPackable>false</IsPackable>
 
+    <LangVersion>8.0</LangVersion>
     <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
     <RootNamespace>Lemon.IntegrationTests</RootNamespace>
     <CodeAnalysisRuleSet>..\StyleCop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="YamlDotNet" Version="8.1.0" />
+    <PackageReference Include="YamlDotNet" Version="8.1.2" />
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" >
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Lemon.IntegrationTests/TestDataBase.cs
+++ b/src/Lemon.IntegrationTests/TestDataBase.cs
@@ -23,9 +23,21 @@ namespace Lemon.IntegrationTests
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using NUnit.Framework;
 
     public static class TestDataBase
     {
+        public static void IgnoreIfFileDoesNotExist(string file)
+        {
+            if (!File.Exists(file)) {
+                TestContext.Progress.WriteLine(
+                    "[{0}] Missing resource file: {1}",
+                    TestContext.CurrentContext.Test.ClassName,
+                    file);
+                Assert.Ignore();
+            }
+        }
+
         public static string RootFromOutputPath {
             get {
                 string envVar = Environment.GetEnvironmentVariable("YARHL_TEST_DIR");
@@ -33,10 +45,11 @@ namespace Lemon.IntegrationTests
                     return envVar;
 
                 string programDir = AppDomain.CurrentDomain.BaseDirectory;
-                return Path.Combine(
+                string path = Path.Combine(
                     programDir,
                     "..", "..", "..", "..", "..",
                     "test_resources");
+                return Path.GetFullPath(path);
             }
         }
 

--- a/src/Lemon.IntegrationTests/Titles/Binary2ObjectTests.cs
+++ b/src/Lemon.IntegrationTests/Titles/Binary2ObjectTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) 2020 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Lemon.IntegrationTests.Titles
+{
+    using NUnit.Framework;
+    using YamlDotNet.Serialization;
+    using YamlDotNet.Serialization.NamingConventions;
+    using Yarhl.FileFormat;
+    using Yarhl.IO;
+
+    public abstract class Binary2ObjectTests<T>
+        where T : IFormat
+    {
+        int initialStreams;
+        BinaryFormat original;
+        string expectedYaml;
+        IConverter<BinaryFormat, T> objectConverter;
+        IConverter<T, BinaryFormat> binaryConverter;
+
+        [OneTimeSetUp]
+        public void SetUpFixture()
+        {
+            expectedYaml = GetObjectYaml();
+            objectConverter = GetToObjectConverter();
+            binaryConverter = GetToBinaryConverter();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            original?.Dispose();
+
+            // Make sure we didn't leave anything without dispose.
+            Assert.That(DataStream.ActiveStreams, Is.EqualTo(initialStreams));
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            // By opening and disposing in each we prevent other tests failing
+            // because the file is still open.
+            initialStreams = DataStream.ActiveStreams;
+            original = GetBinary();
+        }
+
+        [Test]
+        public void TransformToObject()
+        {
+            int numStreams = DataStream.ActiveStreams;
+
+            T actual = objectConverter.Convert(original);
+            string actualYaml = new SerializerBuilder()
+                .WithNamingConvention(UnderscoredNamingConvention.Instance)
+                .Build()
+                .Serialize(actual);
+            Assert.That(expectedYaml, Is.EqualTo(actualYaml));
+
+            // Check everything is virtual node
+            Assert.That(DataStream.ActiveStreams, Is.EqualTo(numStreams));
+        }
+
+        [Test]
+        public void TransformBothWays()
+        {
+            if (binaryConverter == null) {
+                Assert.Ignore();
+            }
+
+            T actual = objectConverter.Convert(original);
+            using var actualBinary = binaryConverter.Convert(actual);
+
+            Assert.That(original.Stream.Compare(actualBinary.Stream), Is.True);
+        }
+
+        protected abstract BinaryFormat GetBinary();
+
+        protected abstract string GetObjectYaml();
+
+        protected abstract IConverter<BinaryFormat, T> GetToObjectConverter();
+
+        protected abstract IConverter<T, BinaryFormat> GetToBinaryConverter();
+    }
+}

--- a/src/Lemon.IntegrationTests/Titles/Binary2TitleMetadataTests.cs
+++ b/src/Lemon.IntegrationTests/Titles/Binary2TitleMetadataTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) 2019 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Lemon.IntegrationTests.Titles
+{
+    using System.IO;
+    using Lemon.Containers.Converters;
+    using Lemon.Titles;
+    using NUnit.Framework;
+    using Yarhl.FileFormat;
+    using Yarhl.FileSystem;
+    using Yarhl.IO;
+
+    [TestFixtureSource(typeof(TestData), nameof(TestData.TmdParams))]
+    public class Binary2TitleMetadataTests : Binary2ObjectTests<TitleMetadata>
+    {
+        readonly string yamlPath;
+        readonly string binaryPath;
+        readonly int offset;
+        readonly int size;
+
+        public Binary2TitleMetadataTests(string yamlPath, string binaryPath, int offset, int size)
+        {
+            this.yamlPath = yamlPath;
+            this.binaryPath = binaryPath;
+            this.offset = offset;
+            this.size = size;
+
+            TestDataBase.IgnoreIfFileDoesNotExist(binaryPath);
+            TestDataBase.IgnoreIfFileDoesNotExist(yamlPath);
+        }
+
+        protected override BinaryFormat GetBinary()
+        {
+            TestContext.WriteLine(binaryPath);
+            var stream = DataStreamFactory.FromFile(binaryPath, FileOpenMode.Read, offset, size);
+            return new BinaryFormat(stream);
+        }
+
+        protected override string GetObjectYaml()
+        {
+            return File.ReadAllText(yamlPath);
+        }
+
+        protected override IConverter<BinaryFormat, TitleMetadata> GetToObjectConverter()
+        {
+            return new Binary2TitleMetadata();
+        }
+
+        protected override IConverter<TitleMetadata, BinaryFormat> GetToBinaryConverter()
+        {
+            TestContext.Progress.WriteLine("Binary converter for TMD not implemented");
+            return null;
+        }
+    }
+}

--- a/src/Lemon.IntegrationTests/Titles/TestData.cs
+++ b/src/Lemon.IntegrationTests/Titles/TestData.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 SceneGate
+// Copyright (c) 2019 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -17,43 +17,32 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Lemon.Titles
+namespace Lemon.IntegrationTests.Titles
 {
-    using System;
+    using System.Collections;
+    using System.IO;
+    using System.Linq;
+    using NUnit.Framework;
 
-    /// <summary>
-    /// Attributes of a CIA content chunk (NCCH).
-    /// </summary>
-    [Flags]
-    public enum ContentAttributes {
-        /// <summary>
-        /// No special attributes.
-        /// </summary>
-        None = 0,
+    public static class TestData
+    {
+        public static IEnumerable TmdParams {
+            get => GetSubstreamAndInfoCollection("tmd.txt");
+        }
 
-        /// <summary>
-        /// The content is encrypted.
-        /// </summary>
-        Encrypted = 1,
+        private static string ResourceDirectory {
+            get => Path.Combine(TestDataBase.RootFromOutputPath, "titles");
+        }
 
-        /// <summary>
-        /// Unknown - The content comes from a disc?
-        /// </summary>
-        Disc = 2,
-
-        /// <summary>
-        /// Unknown.
-        /// </summary>
-        Cfm = 4,
-
-        /// <summary>
-        /// The content is optional.
-        /// </summary>
-        Optional = 0x4000,
-
-        /// <summary>
-        /// The content is shared.
-        /// </summary>
-        Shared = 0x8000,
+        private static IEnumerable GetSubstreamAndInfoCollection(string listName)
+        {
+            return TestDataBase.ReadTestListFile(Path.Combine(ResourceDirectory, listName))
+                    .Select(line => line.Split(','))
+                    .Select(data => new TestFixtureData(
+                        Path.Combine(ResourceDirectory, data[0]),
+                        Path.Combine(ResourceDirectory, data[1]),
+                        int.Parse(data[2]),
+                        int.Parse(data[3])));
+        }
     }
 }

--- a/src/Lemon/Containers/Converters/BinaryCia2NodeContainer.cs
+++ b/src/Lemon/Containers/Converters/BinaryCia2NodeContainer.cs
@@ -122,7 +122,7 @@ namespace Lemon.Containers.Converters
                     offset,
                     chunk.Size);
 
-                if (chunk.Type.HasFlag(ContentAttributes.Encrypted)) {
+                if (chunk.Attributes.HasFlag(ContentAttributes.Encrypted)) {
                     chunkNode.Tags["LEMON_NCCH_ENCRYPTED"] = true;
                 }
 

--- a/src/Lemon/Containers/Converters/BinaryCia2NodeContainer.cs
+++ b/src/Lemon/Containers/Converters/BinaryCia2NodeContainer.cs
@@ -1,0 +1,142 @@
+// Copyright (c) 2020 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Lemon.Containers.Converters
+{
+    using System;
+    using Yarhl.FileFormat;
+    using Yarhl.FileSystem;
+    using Yarhl.IO;
+
+    /// <summary>
+    /// Converter for binary CIA streams into node containers.
+    /// </summary>
+    public class BinaryCia2NodeContainer : IConverter<BinaryFormat, NodeContainerFormat>
+    {
+        const int BlockSize = 64;
+
+        /// <summary>
+        /// Converts a binary CIA format into a container.
+        /// </summary>
+        /// <param name="source">The binary CIA format.</param>
+        /// <returns>The container with the CIA content.</returns>
+        public NodeContainerFormat Convert(BinaryFormat source)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            var stream = source.Stream;
+            Header header = ReadHeader(stream);
+
+            var container = new NodeContainerFormat();
+
+            long certsOffset = header.HeaderSize.Pad(BlockSize);
+            Node certs = NodeFactory.FromSubstream(
+                "certs_chain",
+                stream,
+                certsOffset,
+                header.CertificatesLength);
+
+            long ticketOffset = (certsOffset + header.CertificatesLength).Pad(BlockSize);
+            Node ticket = NodeFactory.FromSubstream(
+                "ticket",
+                stream,
+                ticketOffset,
+                header.TicketLength);
+
+            long tmdOffset = (ticketOffset + header.TicketLength).Pad(BlockSize);
+            Node title = NodeFactory.FromSubstream(
+                "title",
+                stream,
+                tmdOffset,
+                header.TitleMetaLength);
+
+            long contentOffset = (tmdOffset + header.TitleMetaLength).Pad(BlockSize);
+            Node content = NodeFactory.FromSubstream(
+                "content",
+                stream,
+                contentOffset,
+                header.ContentLength);
+
+            long metaOffset = (contentOffset + header.ContentLength).Pad(BlockSize);
+            Node metadata = NodeFactory.FromSubstream(
+                "metadata",
+                stream,
+                metaOffset,
+                header.MetaLength);
+
+            AddNodes(container.Root, certs, ticket, title, content, metadata);
+            return container;
+        }
+
+        static void AddNodes(Node parent, params Node[] children)
+        {
+            foreach (var child in children) {
+                parent.Add(child);
+            }
+        }
+
+        static Header ReadHeader(DataStream stream)
+        {
+            var reader = new DataReader(stream);
+            Header header = new Header {
+                HeaderSize = reader.ReadUInt32(),
+                Type = reader.ReadUInt16(),
+                Version = reader.ReadUInt16(),
+                CertificatesLength = reader.ReadUInt32(),
+                TicketLength = reader.ReadUInt32(),
+                TitleMetaLength = reader.ReadUInt32(),
+                MetaLength = reader.ReadUInt32(),
+                ContentLength = reader.ReadInt64(),
+                ContentIndex = reader.ReadBytes(Header.ContentIndexLength),
+            };
+
+            if (header.Type != 0)
+                throw new FormatException($"Invalid type: '{header.Type}'");
+
+            if (header.Version != 0)
+                throw new FormatException($"Unsupported version: '{header.Version}'");
+
+            return header;
+        }
+
+        private struct Header
+        {
+            public const int ContentIndexLength = 0x2000;
+
+            public uint HeaderSize { get; set; }
+
+            public ushort Type { get; set; }
+
+            public ushort Version { get; set; }
+
+            public uint CertificatesLength { get; set; }
+
+            public uint TicketLength { get; set; }
+
+            public uint TitleMetaLength { get; set; }
+
+            public uint MetaLength { get; set; }
+
+            public long ContentLength { get; set; }
+
+            public byte[] ContentIndex { get; set; }
+        }
+    }
+}

--- a/src/Lemon/Containers/Converters/BinaryCia2NodeContainer.cs
+++ b/src/Lemon/Containers/Converters/BinaryCia2NodeContainer.cs
@@ -94,6 +94,9 @@ namespace Lemon.Containers.Converters
 
         static Header ReadHeader(DataStream stream)
         {
+            // Read header except content index array.
+            // We don't need it as it's a bit array with a bit set for each
+            // number of content (i.e. 0xC0 means two contents).
             var reader = new DataReader(stream);
             Header header = new Header {
                 HeaderSize = reader.ReadUInt32(),
@@ -104,7 +107,6 @@ namespace Lemon.Containers.Converters
                 TitleMetaLength = reader.ReadUInt32(),
                 MetaLength = reader.ReadUInt32(),
                 ContentLength = reader.ReadInt64(),
-                ContentIndex = reader.ReadBytes(Header.ContentIndexLength),
             };
 
             if (header.Type != 0)
@@ -118,8 +120,6 @@ namespace Lemon.Containers.Converters
 
         private struct Header
         {
-            public const int ContentIndexLength = 0x2000;
-
             public uint HeaderSize { get; set; }
 
             public ushort Type { get; set; }
@@ -135,8 +135,6 @@ namespace Lemon.Containers.Converters
             public uint MetaLength { get; set; }
 
             public long ContentLength { get; set; }
-
-            public byte[] ContentIndex { get; set; }
         }
     }
 }

--- a/src/Lemon/Containers/Converters/BinaryCia2NodeContainer.cs
+++ b/src/Lemon/Containers/Converters/BinaryCia2NodeContainer.cs
@@ -122,7 +122,7 @@ namespace Lemon.Containers.Converters
                     offset,
                     chunk.Size);
 
-                if (chunk.Type.HasFlag(ContentTypeFlags.Encrypted)) {
+                if (chunk.Type.HasFlag(ContentAttributes.Encrypted)) {
                     chunkNode.Tags["LEMON_NCCH_ENCRYPTED"] = true;
                 }
 

--- a/src/Lemon/Containers/Converters/BinaryCia2NodeContainer.cs
+++ b/src/Lemon/Containers/Converters/BinaryCia2NodeContainer.cs
@@ -45,6 +45,8 @@ namespace Lemon.Containers.Converters
             Header header = ReadHeader(stream);
 
             var container = new NodeContainerFormat();
+            container.Root.Tags["version"] = header.Version;
+            container.Root.Tags["type"] = header.Type;
 
             long certsOffset = header.HeaderSize.Pad(BlockSize);
             Node certs = NodeFactory.FromSubstream(

--- a/src/Lemon/Containers/Converters/Ivfc/LevelStream.cs
+++ b/src/Lemon/Containers/Converters/Ivfc/LevelStream.cs
@@ -84,7 +84,7 @@ namespace Lemon.Containers.Converters.Ivfc
 
         /// <summary>
         /// Gets a value indicating whether this <see cref="LevelStream" />
-        /// has been dispsosed.
+        /// has been disposed.
         /// </summary>
         public bool Disposed { get; private set; }
 
@@ -162,7 +162,7 @@ namespace Lemon.Containers.Converters.Ivfc
         /// <summary>
         /// Releases all resources used by the object.
         /// </summary>
-        /// <param name="freeManaged">Whethever to free the managed resources too.</param>
+        /// <param name="freeManaged">Whether to free the managed resources too.</param>
         protected virtual void Dispose(bool freeManaged)
         {
             if (Disposed) {

--- a/src/Lemon/Containers/Converters/NodeContainer2BinaryIvfc.cs
+++ b/src/Lemon/Containers/Converters/NodeContainer2BinaryIvfc.cs
@@ -149,7 +149,7 @@ namespace Lemon.Containers.Converters
             return binary;
         }
 
-        void WriteHeader(DataWriter writer, long[] sizes)
+        static void WriteHeader(DataWriter writer, long[] sizes)
         {
             const uint HeaderSize = 0x5C;
 

--- a/src/Lemon/Containers/Converters/NodeContainer2BinaryIvfc.cs
+++ b/src/Lemon/Containers/Converters/NodeContainer2BinaryIvfc.cs
@@ -115,7 +115,7 @@ namespace Lemon.Containers.Converters
             long level3Offset = binary.Stream.Position;
 
             // Increase the base length so we can create a substream of the correct size
-            // This operation doesn't write and it returns almost inmediatly,
+            // This operation doesn't write and it returns almost immediately,
             // the write happens on the first byte written on the new file space.
             long level3Padded = levelSizes[3].Pad(BlockSize);
             binary.Stream.BaseStream.SetLength(binary.Stream.BaseStream.Length + level3Padded);

--- a/src/Lemon/Containers/Formats/Ncsd.cs
+++ b/src/Lemon/Containers/Formats/Ncsd.cs
@@ -24,7 +24,7 @@ namespace Lemon.Containers.Formats
     /// <summary>
     /// Nintendo CTR SD.
     /// This is the format for the CCI, NAND and CSU specializations.
-    /// It can contains upto 8 containers / nodes.
+    /// It can contains up to 8 containers / nodes.
     /// </summary>
     public class Ncsd : NodeContainerFormat
     {

--- a/src/Lemon/Lemon.csproj
+++ b/src/Lemon/Lemon.csproj
@@ -16,6 +16,7 @@
     <PackageProjectUrl>https://github.com/SceneGate/Lemon/</PackageProjectUrl>
     <PackageTags>romhacking;n3ds;scenegate</PackageTags>
 
+    <LangVersion>8.0</LangVersion>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>Lemon</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Lemon/Lemon.csproj
+++ b/src/Lemon/Lemon.csproj
@@ -27,11 +27,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.6.0.16497" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.9.0.19135">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Lemon/Lemon.csproj
+++ b/src/Lemon/Lemon.csproj
@@ -24,6 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="YamlDotNet" Version="8.1.2" />
     <PackageReference Include="LibLog" Version="5.0.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Lemon/Titles/Binary2TitleMetadata.cs
+++ b/src/Lemon/Titles/Binary2TitleMetadata.cs
@@ -100,7 +100,7 @@ namespace Lemon.Titles
             var chunk = new ContentChunkRecord {
                 Id = reader.ReadInt32(),
                 Index = reader.ReadInt16(),
-                Type = (ContentAttributes)reader.ReadInt16(),
+                Attributes = (ContentAttributes)reader.ReadInt16(),
                 Size = reader.ReadInt64(),
                 Hash = reader.ReadBytes(0x20),
             };

--- a/src/Lemon/Titles/Binary2TitleMetadata.cs
+++ b/src/Lemon/Titles/Binary2TitleMetadata.cs
@@ -100,7 +100,7 @@ namespace Lemon.Titles
             var chunk = new ContentChunkRecord {
                 Id = reader.ReadInt32(),
                 Index = reader.ReadInt16(),
-                Type = (ContentTypeFlags)reader.ReadInt16(),
+                Type = (ContentAttributes)reader.ReadInt16(),
                 Size = reader.ReadInt64(),
                 Hash = reader.ReadBytes(0x20),
             };

--- a/src/Lemon/Titles/Binary2TitleMetadata.cs
+++ b/src/Lemon/Titles/Binary2TitleMetadata.cs
@@ -1,0 +1,125 @@
+// Copyright (c) 2020 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Lemon.Titles
+{
+    using System;
+    using Yarhl.FileFormat;
+    using Yarhl.IO;
+
+    /// <summary>
+    /// Deserializer of binary title metadata.
+    /// </summary>
+    public class Binary2TitleMetadata : IConverter<BinaryFormat, TitleMetadata>
+    {
+        const int NumContentInfo = 64;
+        const int InfoRecordSize = 0x24;
+
+        /// <summary>
+        /// Converts a binary format into a title metadata object.
+        /// </summary>
+        /// <param name="source">The source binary.</param>
+        /// <returns>The deserializer title metadata.</returns>
+        public TitleMetadata Convert(BinaryFormat source)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            var reader = new DataReader(source.Stream) {
+                Endianness = EndiannessMode.BigEndian,
+            };
+
+            // TODO: Validate signature
+            uint signType = reader.ReadUInt32();
+            int signSize = GetSignatureSize(signType);
+            source.Stream.Position += signSize;
+
+            TitleMetadata metadata = ReadHeader(reader, out int contentCount);
+
+            // TODO: Validate chunk records
+            source.Stream.Position += NumContentInfo * InfoRecordSize;
+
+            for (int i = 0; i < contentCount; i++) {
+                ContentChunkRecord chunk = ReadChunkRecord(reader);
+                metadata.Chunks.Add(chunk);
+            }
+
+            return metadata;
+        }
+
+        static TitleMetadata ReadHeader(DataReader reader, out int contentCount)
+        {
+            var metadata = new TitleMetadata();
+            metadata.SignatureIssuer = reader.ReadString(0x40).Replace("\0", string.Empty);
+            metadata.Version = reader.ReadByte();
+            metadata.CaCrlVersion = reader.ReadByte();
+            metadata.SignerCrlVersion = reader.ReadByte();
+            reader.Stream.Position++; // padding
+
+            metadata.SystemVersion = reader.ReadInt64();
+            metadata.TitleId = reader.ReadInt64();
+            metadata.TitleType = reader.ReadInt32();
+            metadata.GroupId = reader.ReadInt16();
+
+            metadata.SaveSize = reader.ReadInt32();
+            metadata.SrlPrivateSaveSize = reader.ReadInt32();
+            reader.Stream.Position += 4; // reserved
+
+            metadata.SrlFlag = reader.ReadByte();
+            reader.Stream.Position += 0x31; // reserved
+
+            metadata.AccessRights = reader.ReadInt32();
+            metadata.TitleVersion = reader.ReadInt16();
+            contentCount = reader.ReadInt16();
+            metadata.BootContent = reader.ReadInt16();
+            reader.Stream.Position += 2; // padding
+
+            reader.Stream.Position += 0x20; // SHA-256 hash content info records
+
+            return metadata;
+        }
+
+        static ContentChunkRecord ReadChunkRecord(DataReader reader)
+        {
+            var chunk = new ContentChunkRecord {
+                Id = reader.ReadInt32(),
+                Index = reader.ReadInt16(),
+                Type = (ContentTypeFlags)reader.ReadInt16(),
+                Size = reader.ReadInt64(),
+                Hash = reader.ReadBytes(0x20),
+            };
+
+            return chunk;
+        }
+
+        static int GetSignatureSize(uint type)
+        {
+            // Including padding
+            return type switch {
+                0x010000 => 0x23C,
+                0x010001 => 0x13C,
+                0x010002 => 0x7C,
+                0x010003 => 0x23C,
+                0x010004 => 0x13C,
+                0x010005 => 0x7C,
+                _ => throw new NotSupportedException(),
+            };
+        }
+    }
+}

--- a/src/Lemon/Titles/ContentAttributes.cs
+++ b/src/Lemon/Titles/ContentAttributes.cs
@@ -25,7 +25,7 @@ namespace Lemon.Titles
     /// Attributes of a CIA content chunk (NCCH).
     /// </summary>
     [Flags]
-    public enum ContentTypeFlags {
+    public enum ContentAttributes {
         /// <summary>
         /// The content is encrypted.
         /// </summary>

--- a/src/Lemon/Titles/ContentChunkRecord.cs
+++ b/src/Lemon/Titles/ContentChunkRecord.cs
@@ -20,6 +20,7 @@
 namespace Lemon.Titles
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
     /// Information about a CIA content chunk.
@@ -39,7 +40,7 @@ namespace Lemon.Titles
         /// <summary>
         /// Gets or sets the type of content.
         /// </summary>
-        public ContentTypeFlags Type { get; set; }
+        public ContentAttributes Type { get; set; }
 
         /// <summary>
         /// Gets or sets the chunk size.
@@ -49,6 +50,10 @@ namespace Lemon.Titles
         /// <summary>
         /// Gets or sets the chunk hash.
         /// </summary>
+        [SuppressMessage(
+            "Performance",
+            "CA1819",
+            Justification = "This is how .NET API works with hashes too and this is a model")]
         public byte[] Hash { get; set; }
 
         /// <summary>

--- a/src/Lemon/Titles/ContentChunkRecord.cs
+++ b/src/Lemon/Titles/ContentChunkRecord.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 SceneGate
+// Copyright (c) 2020 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -17,32 +17,52 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Lemon.Containers.Formats
+namespace Lemon.Titles
 {
-    using Yarhl.FileSystem;
+    using System;
 
     /// <summary>
-    /// Nintendo Content Container Header.
-    /// This is the format for the CXI and CFA specialization.
-    /// It can contain up to two file systems and several special files.
+    /// Information about a CIA content chunk.
     /// </summary>
-    public class Ncch : NodeContainerFormat
+    public class ContentChunkRecord
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Ncch"/> class.
+        /// Gets or sets the ID of the chunk.
         /// </summary>
-        public Ncch()
-        {
-            Header = new NcchHeader();
-        }
+        public int Id { get; set; }
 
         /// <summary>
-        /// Gets or sets the header.
+        /// Gets or sets the chunk index which maps into its actual content.
         /// </summary>
-        /// <value>The header.</value>
-        public NcchHeader Header {
-            get;
-            set;
+        public short Index { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of content.
+        /// </summary>
+        public ContentTypeFlags Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the chunk size.
+        /// </summary>
+        public long Size { get; set; }
+
+        /// <summary>
+        /// Gets or sets the chunk hash.
+        /// </summary>
+        public byte[] Hash { get; set; }
+
+        /// <summary>
+        /// Gets the name of the chunk from its index.
+        /// </summary>
+        /// <returns>The chunk's name.</returns>
+        public string GetChunkName()
+        {
+            return Index switch {
+                0 => "program",
+                1 => "manual",
+                2 => "download_play",
+                _ => throw new NotSupportedException(),
+            };
         }
     }
 }

--- a/src/Lemon/Titles/ContentChunkRecord.cs
+++ b/src/Lemon/Titles/ContentChunkRecord.cs
@@ -21,6 +21,7 @@ namespace Lemon.Titles
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
+    using YamlDotNet.Serialization;
 
     /// <summary>
     /// Information about a CIA content chunk.
@@ -40,7 +41,7 @@ namespace Lemon.Titles
         /// <summary>
         /// Gets or sets the type of content.
         /// </summary>
-        public ContentAttributes Type { get; set; }
+        public ContentAttributes Attributes { get; set; }
 
         /// <summary>
         /// Gets or sets the chunk size.
@@ -54,6 +55,7 @@ namespace Lemon.Titles
             "Performance",
             "CA1819",
             Justification = "This is how .NET API works with hashes too and this is a model")]
+        [YamlIgnore]
         public byte[] Hash { get; set; }
 
         /// <summary>

--- a/src/Lemon/Titles/ContentTypeFlags.cs
+++ b/src/Lemon/Titles/ContentTypeFlags.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 SceneGate
+// Copyright (c) 2020 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -17,32 +17,38 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Lemon.Containers.Formats
+namespace Lemon.Titles
 {
-    using Yarhl.FileSystem;
+    using System;
 
     /// <summary>
-    /// Nintendo Content Container Header.
-    /// This is the format for the CXI and CFA specialization.
-    /// It can contain up to two file systems and several special files.
+    /// Attributes of a CIA content chunk (NCCH).
     /// </summary>
-    public class Ncch : NodeContainerFormat
-    {
+    [Flags]
+    public enum ContentTypeFlags {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Ncch"/> class.
+        /// The content is encrypted.
         /// </summary>
-        public Ncch()
-        {
-            Header = new NcchHeader();
-        }
+        Encrypted = 1,
 
         /// <summary>
-        /// Gets or sets the header.
+        /// Unknown - The content comes from a disc?
         /// </summary>
-        /// <value>The header.</value>
-        public NcchHeader Header {
-            get;
-            set;
-        }
+        Disc = 2,
+
+        /// <summary>
+        /// Unknown.
+        /// </summary>
+        Cfm = 4,
+
+        /// <summary>
+        /// The content is optional.
+        /// </summary>
+        Optional = 0x4000,
+
+        /// <summary>
+        /// The content is shared.
+        /// </summary>
+        Shared = 0x8000,
     }
 }

--- a/src/Lemon/Titles/TitleMetadata.cs
+++ b/src/Lemon/Titles/TitleMetadata.cs
@@ -1,0 +1,112 @@
+// Copyright (c) 2020 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Lemon.Titles
+{
+    using System.Collections.ObjectModel;
+    using Yarhl.FileFormat;
+
+    /// <summary>
+    /// E-shop title metadata.
+    /// </summary>
+    public class TitleMetadata : IFormat
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether the title metadata has a
+        /// valid signature.
+        /// </summary>
+        public bool ValidSignature { get; set; }
+
+        /// <summary>
+        /// Gets or sets the signature issuer.
+        /// </summary>
+        public string SignatureIssuer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of the title metadata.
+        /// </summary>
+        public byte Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of the CA CRL.
+        /// </summary>
+        public byte CaCrlVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of the signer CRL.
+        /// </summary>
+        public byte SignerCrlVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets the system's version.
+        /// </summary>
+        public long SystemVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ID of the title.
+        /// </summary>
+        public long TitleId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of title.
+        /// </summary>
+        public int TitleType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ID of the group.
+        /// </summary>
+        public short GroupId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the size of the save file data.
+        /// </summary>
+        public int SaveSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the size of the private data of a SRL (DSi) save file.
+        /// </summary>
+        /// <value></value>
+        public int SrlPrivateSaveSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the SRL (DSi) flags.
+        /// </summary>
+        public byte SrlFlag { get; set; }
+
+        /// <summary>
+        /// Gets or sets the access rights.
+        /// </summary>
+        public int AccessRights { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of the title.
+        /// </summary>
+        public short TitleVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets the index of the bootable content.
+        /// </summary>
+        public int BootContent { get; set; }
+
+        /// <summary>
+        /// Gets a collection of content chunks.
+        /// </summary>
+        public Collection<ContentChunkRecord> Chunks { get; } = new Collection<ContentChunkRecord>();
+    }
+}

--- a/src/Lemon/Titles/TitleMetadata.cs
+++ b/src/Lemon/Titles/TitleMetadata.cs
@@ -28,6 +28,14 @@ namespace Lemon.Titles
     public class TitleMetadata : IFormat
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="TitleMetadata" /> class.
+        /// </summary>
+        public TitleMetadata()
+        {
+            Chunks = new Collection<ContentChunkRecord>();
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether the title metadata has a
         /// valid signature.
         /// </summary>
@@ -106,6 +114,6 @@ namespace Lemon.Titles
         /// <summary>
         /// Gets a collection of content chunks.
         /// </summary>
-        public Collection<ContentChunkRecord> Chunks { get; } = new Collection<ContentChunkRecord>();
+        public Collection<ContentChunkRecord> Chunks { get; private set; }
     }
 }

--- a/src/Lemon/Titles/TitleMetadata.cs
+++ b/src/Lemon/Titles/TitleMetadata.cs
@@ -81,7 +81,6 @@ namespace Lemon.Titles
         /// <summary>
         /// Gets or sets the size of the private data of a SRL (DSi) save file.
         /// </summary>
-        /// <value></value>
         public int SrlPrivateSaveSize { get; set; }
 
         /// <summary>

--- a/test_resources/containers/.gitignore
+++ b/test_resources/containers/.gitignore
@@ -2,3 +2,6 @@
 *.3ds
 *.csu
 nand.bin
+*.cia
+
+!fake*

--- a/test_resources/containers/aofm_cia.yml
+++ b/test_resources/containers/aofm_cia.yml
@@ -30,12 +30,25 @@ children:
     children:
 
   - name: content
-    format_type: Yarhl.IO.BinaryFormat
-    stream_offset: 0x3940
-    stream_length: 0x0B1E1000
+    format_type: Yarhl.FileSystem.NodeContainerFormat
     tags:
     check_children: true
     children:
+      - name: program
+        format_type: Yarhl.IO.BinaryFormat
+        stream_offset: 0x3940
+        stream_length: 0x0B17D000
+        tags:
+        check_children: true
+        children:
+
+      - name: manual
+        format_type: Yarhl.IO.BinaryFormat
+        stream_offset: 0x0B180940
+        stream_length: 0x064000
+        tags:
+        check_children: true
+        children:
 
   - name: metadata
     format_type: Yarhl.IO.BinaryFormat

--- a/test_resources/containers/aofm_cia.yml
+++ b/test_resources/containers/aofm_cia.yml
@@ -1,46 +1,46 @@
-name: root
-format_type: Yarhl.FileSystem.NodeContainerFormat
+name: NodeContainerRoot
+format_type: null
 tags:
-  - version: 0
-  - type: 0
+  version: 0
+  type: 0
 check_children: true
 children:
   - name: certs_chain
     format_type: Yarhl.IO.BinaryFormat
     stream_offset: 0x2040
     stream_length: 0x0A00
-    tags: []
+    tags:
     check_children: true
-    children: []
+    children:
 
   - name: ticket
     format_type: Yarhl.IO.BinaryFormat
     stream_offset: 0x2A40
     stream_length: 0x0350
-    tags: []
+    tags:
     check_children: true
-    children: []
+    children:
 
   - name: title
     format_type: Yarhl.IO.BinaryFormat
     stream_offset: 0x2DC0
     stream_length: 0x0B64
-    tags: []
+    tags:
     check_children: true
-    children: []
+    children:
 
   - name: content
     format_type: Yarhl.IO.BinaryFormat
     stream_offset: 0x3940
     stream_length: 0x0B1E1000
-    tags: []
+    tags:
     check_children: true
-    children: []
+    children:
 
   - name: metadata
     format_type: Yarhl.IO.BinaryFormat
     stream_offset: 0x0B1E4940
     stream_length: 0x3AC0
-    tags: []
+    tags:
     check_children: true
-    children: []
+    children:

--- a/test_resources/containers/aofm_cia.yml
+++ b/test_resources/containers/aofm_cia.yml
@@ -1,0 +1,46 @@
+name: root
+format_type: Yarhl.FileSystem.NodeContainerFormat
+tags:
+  - version: 0
+  - type: 0
+check_children: true
+children:
+  - name: certs_chain
+    format_type: Yarhl.IO.BinaryFormat
+    stream_offset: 0x2040
+    stream_length: 0x0A00
+    tags: []
+    check_children: true
+    children: []
+
+  - name: ticket
+    format_type: Yarhl.IO.BinaryFormat
+    stream_offset: 0x2A40
+    stream_length: 0x0350
+    tags: []
+    check_children: true
+    children: []
+
+  - name: title
+    format_type: Yarhl.IO.BinaryFormat
+    stream_offset: 0x2DC0
+    stream_length: 0x0B64
+    tags: []
+    check_children: true
+    children: []
+
+  - name: content
+    format_type: Yarhl.IO.BinaryFormat
+    stream_offset: 0x3940
+    stream_length: 0x0B1E1000
+    tags: []
+    check_children: true
+    children: []
+
+  - name: metadata
+    format_type: Yarhl.IO.BinaryFormat
+    stream_offset: 0x0B1E4940
+    stream_length: 0x3AC0
+    tags: []
+    check_children: true
+    children: []

--- a/test_resources/containers/aofm_cia_legit.yml
+++ b/test_resources/containers/aofm_cia_legit.yml
@@ -1,46 +1,46 @@
-name: root
-format_type: Yarhl.FileSystem.NodeContainerFormat
+name: NodeContainerRoot
+format_type: null
 tags:
-  - version: 0
-  - type: 0
+  version: 0
+  type: 0
 check_children: true
 children:
   - name: certs_chain
     format_type: Yarhl.IO.BinaryFormat
     stream_offset: 0x2040
     stream_length: 0x0A00
-    tags: []
+    tags:
     check_children: true
-    children: []
+    children:
 
   - name: ticket
     format_type: Yarhl.IO.BinaryFormat
     stream_offset: 0x2A40
     stream_length: 0x0350
-    tags: []
+    tags:
     check_children: true
-    children: []
+    children:
 
   - name: title
     format_type: Yarhl.IO.BinaryFormat
     stream_offset: 0x2DC0
     stream_length: 0x0B64
-    tags: []
+    tags:
     check_children: true
-    children: []
+    children:
 
   - name: content
     format_type: Yarhl.IO.BinaryFormat
     stream_offset: 0x3940
     stream_length: 0x0B1E1000
-    tags: []
+    tags:
     check_children: true
-    children: []
+    children:
 
   - name: metadata
     format_type: Yarhl.IO.BinaryFormat
     stream_offset: 0x0B1E4940
     stream_length: 0x3AC0
-    tags: []
+    tags:
     check_children: true
-    children: []
+    children:

--- a/test_resources/containers/aofm_cia_legit.yml
+++ b/test_resources/containers/aofm_cia_legit.yml
@@ -1,0 +1,46 @@
+name: root
+format_type: Yarhl.FileSystem.NodeContainerFormat
+tags:
+  - version: 0
+  - type: 0
+check_children: true
+children:
+  - name: certs_chain
+    format_type: Yarhl.IO.BinaryFormat
+    stream_offset: 0x2040
+    stream_length: 0x0A00
+    tags: []
+    check_children: true
+    children: []
+
+  - name: ticket
+    format_type: Yarhl.IO.BinaryFormat
+    stream_offset: 0x2A40
+    stream_length: 0x0350
+    tags: []
+    check_children: true
+    children: []
+
+  - name: title
+    format_type: Yarhl.IO.BinaryFormat
+    stream_offset: 0x2DC0
+    stream_length: 0x0B64
+    tags: []
+    check_children: true
+    children: []
+
+  - name: content
+    format_type: Yarhl.IO.BinaryFormat
+    stream_offset: 0x3940
+    stream_length: 0x0B1E1000
+    tags: []
+    check_children: true
+    children: []
+
+  - name: metadata
+    format_type: Yarhl.IO.BinaryFormat
+    stream_offset: 0x0B1E4940
+    stream_length: 0x3AC0
+    tags: []
+    check_children: true
+    children: []

--- a/test_resources/containers/aofm_cia_legit.yml
+++ b/test_resources/containers/aofm_cia_legit.yml
@@ -30,12 +30,27 @@ children:
     children:
 
   - name: content
-    format_type: Yarhl.IO.BinaryFormat
-    stream_offset: 0x3940
-    stream_length: 0x0B1E1000
+    format_type: Yarhl.FileSystem.NodeContainerFormat
     tags:
     check_children: true
     children:
+      - name: program
+        format_type: Yarhl.IO.BinaryFormat
+        stream_offset: 0x3940
+        stream_length: 0x0B17D000
+        tags:
+          LEMON_NCCH_ENCRYPTED: True
+        check_children: true
+        children:
+
+      - name: manual
+        format_type: Yarhl.IO.BinaryFormat
+        stream_offset: 0x0B180940
+        stream_length: 0x064000
+        tags:
+          LEMON_NCCH_ENCRYPTED: True
+        check_children: true
+        children:
 
   - name: metadata
     format_type: Yarhl.IO.BinaryFormat

--- a/test_resources/containers/aofm_exefs.yml
+++ b/test_resources/containers/aofm_exefs.yml
@@ -1,31 +1,36 @@
-name: system
-format_type: Yarhl.FileSystem.NodeContainerFormat
+name: NodeContainerRoot
+format_type: null
+tags:
 check_children: true
 children:
   - name: .code
     format_type: Yarhl.IO.BinaryFormat
     stream_offset: 19968
     stream_length: 980732
+    tags:
     check_children: true
-    children: []
+    children:
 
   - name: banner
     format_type: Yarhl.IO.BinaryFormat
     stream_offset: 1000960
     stream_length: 165064
+    tags:
     check_children: true
-    children: []
+    children:
 
   - name: icon
     format_type: Yarhl.IO.BinaryFormat
     stream_offset: 1166336
     stream_length: 14016
+    tags:
     check_children: true
-    children: []
+    children:
 
   - name: logo
     format_type: Yarhl.IO.BinaryFormat
     stream_offset: 1180672
     stream_length: 8192
+    tags:
     check_children: true
-    children: []
+    children:

--- a/test_resources/containers/aofm_ivfc.yml
+++ b/test_resources/containers/aofm_ivfc.yml
@@ -1,70 +1,85 @@
-name: rom
-format_type: Yarhl.FileSystem.NodeContainerFormat
+name: NodeContainerRoot
+format_type: null
+tags:
 check_children: true
 children:
   - name: gkk
     format_type: Yarhl.FileSystem.NodeContainerFormat
+    tags:
     check_children: false
     children:
   - name: lv5
     format_type: Yarhl.FileSystem.NodeContainerFormat
+    tags:
     check_children: true
     children:
       - name: fix.xr
         format_type: Yarhl.IO.BinaryFormat
         stream_offset: 169007792
         stream_length: 24592
+        tags:
         check_children: true
         children:
       - name: chr
         format_type: Yarhl.FileSystem.NodeContainerFormat
+        tags:
         check_children: true
         children:
           - name: c100.xc
             format_type: Yarhl.IO.BinaryFormat
             stream_offset: 169032384
             stream_length: 281444
+            tags:
             check_children: true
             children:
           - name: c101.xc
             format_type: Yarhl.IO.BinaryFormat
             stream_offset: 169313840
             stream_length: 283876
+            tags:
             check_children: true
             children:
           - name: c102.xc
             format_type: Yarhl.IO.BinaryFormat
             stream_offset: 169597728
             stream_length: 314324
+            tags:
             check_children: true
             children:
           - name: c103.xc
             format_type: Yarhl.IO.BinaryFormat
             stream_offset: 169912064
             stream_length: 350356
+            tags:
             check_children: true
             children:
       - name: fnt
         format_type: Yarhl.FileSystem.NodeContainerFormat
+        tags:
         check_children: false
         children:
       - name: menu
         format_type: Yarhl.FileSystem.NodeContainerFormat
+        tags:
         check_children: false
         children:
       - name: mov
         format_type: Yarhl.FileSystem.NodeContainerFormat
+        tags:
         check_children: false
         children:
       - name: seq
         format_type: Yarhl.FileSystem.NodeContainerFormat
+        tags:
         check_children: false
         children:
       - name: sky
         format_type: Yarhl.FileSystem.NodeContainerFormat
+        tags:
         check_children: false
         children:
       - name: snd
         format_type: Yarhl.FileSystem.NodeContainerFormat
+        tags:
         check_children: false
         children:

--- a/test_resources/containers/cia.txt
+++ b/test_resources/containers/cia.txt
@@ -1,6 +1,3 @@
-# Manually created and committed
-# TODO
-
 # Optionals not committed
-aofm.cia,aofm_cia.yml
-aofm_legit.cia,aofm_cia_legit.yml
+aofm_cia.yml,aofm.cia
+aofm_cia_legit.yml,aofm_legit.cia

--- a/test_resources/containers/cia.txt
+++ b/test_resources/containers/cia.txt
@@ -1,0 +1,6 @@
+# Manually created and committed
+# TODO
+
+# Optionals not committed
+aofm.cia,aofm_cia.yml
+aofm_legit.cia,aofm_cia_legit.yml

--- a/test_resources/containers/fake_exefs.yml
+++ b/test_resources/containers/fake_exefs.yml
@@ -1,24 +1,28 @@
-name: system
-format_type: Yarhl.FileSystem.NodeContainerFormat
+name: NodeContainerRoot
+format_type: null
+tags:
 check_children: true
 children:
   - name: .code
     format_type: Yarhl.IO.BinaryFormat
     stream_offset: 17408
     stream_length: 32
+    tags:
     check_children: true
-    children: []
+    children:
 
   - name: banner
     format_type: Yarhl.IO.BinaryFormat
     stream_offset: 17920
     stream_length: 64
+    tags:
     check_children: true
-    children: []
+    children:
 
   - name: randomm
     format_type: Yarhl.IO.BinaryFormat
     stream_offset: 18432
     stream_length: 80
+    tags:
     check_children: true
-    children: []
+    children:

--- a/test_resources/titles/aofm_tmd.yml
+++ b/test_resources/titles/aofm_tmd.yml
@@ -1,0 +1,24 @@
+valid_signature: false
+signature_issuer: Root-CA00000003-CP0000000b
+version: 1
+ca_crl_version: 0
+signer_crl_version: 0
+system_version: 0
+title_id: 1125899907790080
+title_type: 64
+group_id: 0
+save_size: 2048
+srl_private_save_size: 0
+srl_flag: 0
+access_rights: 0
+title_version: 0
+boot_content: 0
+chunks:
+- id: 0
+  index: 0
+  attributes: None
+  size: 186109952
+- id: 1
+  index: 1
+  attributes: None
+  size: 409600

--- a/test_resources/titles/aofm_tmd_legit.yml
+++ b/test_resources/titles/aofm_tmd_legit.yml
@@ -1,0 +1,24 @@
+valid_signature: false
+signature_issuer: Root-CA00000003-CP0000000b
+version: 1
+ca_crl_version: 0
+signer_crl_version: 0
+system_version: 0
+title_id: 1125899907790080
+title_type: 64
+group_id: 0
+save_size: 2048
+srl_private_save_size: 0
+srl_flag: 0
+access_rights: 0
+title_version: 0
+boot_content: 0
+chunks:
+- id: 0
+  index: 0
+  attributes: Encrypted
+  size: 186109952
+- id: 1
+  index: 1
+  attributes: Encrypted
+  size: 409600

--- a/test_resources/titles/tmd.txt
+++ b/test_resources/titles/tmd.txt
@@ -1,0 +1,3 @@
+# Optionals not committed
+aofm_tmd.yml,../containers/aofm.cia,11712,2916
+aofm_tmd_legit.yml,../containers/aofm_legit.cia,11712,2916


### PR DESCRIPTION
Add support to unpack the content of non-encrypted CIA files and implement a deserializer for _title metadata_ (TMD) files.

Additional changes:

- Refactor tests to share code.
- Fix warnings
- Bump dependencies