### PR TITLE
Unpack the extended header and access descriptor from the NCCH

### DIFF
--- a/test_resources/containers/aofm_program.yml
+++ b/test_resources/containers/aofm_program.yml
@@ -1,4 +1,4 @@
 signature_length: 256
-regions_offset: [2560, 3072, 1175552]
-regions_size: [512, 1169408, 184934400]
-available_regions: ["sdk_info.txt", "system", "rom"]
+regions_offset: [0x200, 0x600, 2560, 3072, 1175552]
+regions_size: [0x400, 0x400, 512, 1169408, 184934400]
+available_regions: ["extended_header", "access_descriptor", "sdk_info.txt", "system", "rom"]

--- a/test_resources/containers/update_program.yml
+++ b/test_resources/containers/update_program.yml
@@ -1,4 +1,4 @@
 signature_length: 256
-regions_offset: [2560, 10752, 421888]
-regions_size: [8192, 410624, 147668992]
-available_regions: ["logo.bin", "system", "rom"]
+regions_offset: [0x200, 0x600, 2560, 10752, 421888]
+regions_size: [0x400, 0x400, 8192, 410624, 147668992]
+available_regions: ["extended_header", "access_descriptor", "logo.bin", "system", "rom"]


### PR DESCRIPTION
If the NCCH contains an extended header (CXI), then add it as a child. In that case, add also the access descriptor.