### PR TITLE
Implement TMD generation when packing a CIA

### DIFF
--- a/src/Lemon/Containers/Converters/BinaryCia2NodeContainer.cs
+++ b/src/Lemon/Containers/Converters/BinaryCia2NodeContainer.cs
@@ -75,8 +75,6 @@ namespace SceneGate.Lemon.Containers.Converters
             long contentOffset = (tmdOffset + header.TitleMetaLength).Pad(BlockSize);
             Node content = UnpackContent(title, stream, contentOffset);
 
-            title = title.TransformWith<Binary2TitleMetadata>();
-
             long metaOffset = (contentOffset + header.ContentLength).Pad(BlockSize);
             Node metadata = NodeFactory.FromSubstream(
                 "metadata",

--- a/src/Lemon/Containers/Converters/BinaryCia2NodeContainer.cs
+++ b/src/Lemon/Containers/Converters/BinaryCia2NodeContainer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 SceneGate
+﻿// Copyright (c) 2020 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -74,6 +74,8 @@ namespace SceneGate.Lemon.Containers.Converters
 
             long contentOffset = (tmdOffset + header.TitleMetaLength).Pad(BlockSize);
             Node content = UnpackContent(title, stream, contentOffset);
+
+            title = title.TransformWith<Binary2TitleMetadata>();
 
             long metaOffset = (contentOffset + header.ContentLength).Pad(BlockSize);
             Node metadata = NodeFactory.FromSubstream(

--- a/src/Lemon/Titles/Binary2TitleMetadata.cs
+++ b/src/Lemon/Titles/Binary2TitleMetadata.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 SceneGate
+﻿// Copyright (c) 2020 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -46,12 +46,16 @@ namespace SceneGate.Lemon.Titles
                 Endianness = EndiannessMode.BigEndian,
             };
 
+            TitleMetadata metadata = new TitleMetadata();
+
             // TODO: Validate signature
             uint signType = reader.ReadUInt32();
+            metadata.SignType = signType;
             int signSize = GetSignatureSize(signType);
+            metadata.SignSize = signSize;
             source.Stream.Position += signSize;
 
-            TitleMetadata metadata = ReadHeader(reader, out int contentCount);
+            metadata = ReadHeader(reader, out int contentCount, metadata);
 
             // TODO: Validate chunk records
             source.Stream.Position += NumContentInfo * InfoRecordSize;
@@ -64,9 +68,8 @@ namespace SceneGate.Lemon.Titles
             return metadata;
         }
 
-        static TitleMetadata ReadHeader(DataReader reader, out int contentCount)
+        static TitleMetadata ReadHeader(DataReader reader, out int contentCount, TitleMetadata metadata)
         {
-            var metadata = new TitleMetadata();
             metadata.SignatureIssuer = reader.ReadString(0x40).Replace("\0", string.Empty);
             metadata.Version = reader.ReadByte();
             metadata.CaCrlVersion = reader.ReadByte();

--- a/src/Lemon/Titles/ContentInfoRecord.cs
+++ b/src/Lemon/Titles/ContentInfoRecord.cs
@@ -1,0 +1,52 @@
+﻿// ContentInfoRecord.cs
+//
+// Author:
+//       Maxwell Ruiz maxwellaquaruiz@gmail.com
+//
+// Copyright (c) 2022 Maxwell Ruiz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+namespace SceneGate.Lemon.Titles
+{
+    /// <summary>
+    /// Information about a CIA content info record.
+    /// </summary>
+    public class ContentInfoRecord
+    {
+        /// <summary>
+        /// Gets or sets the content index offset.
+        /// </summary>
+        public short IndexOffset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content command count (number of chunks to hash).
+        /// </summary>
+        public short CommandCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the record hash.
+        /// </summary>
+        public byte[] Hash { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether if the info record is empty.
+        /// </summary>
+        public bool IsEmpty { get; set; }
+    }
+}

--- a/src/Lemon/Titles/TitleMetadata.cs
+++ b/src/Lemon/Titles/TitleMetadata.cs
@@ -32,6 +32,7 @@ namespace SceneGate.Lemon.Titles
         /// </summary>
         public TitleMetadata()
         {
+            InfoRecords = new Collection<ContentInfoRecord>();
             Chunks = new Collection<ContentChunkRecord>();
         }
 
@@ -41,9 +42,9 @@ namespace SceneGate.Lemon.Titles
         public uint SignType { get; set; }
 
         /// <summary>
-        /// Gets or sets the signature size.
+        /// Gets or sets the signature.
         /// </summary>
-        public int SignSize { get; set; }
+        public byte[] Signature { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the title metadata has a
@@ -120,6 +121,16 @@ namespace SceneGate.Lemon.Titles
         /// Gets or sets the index of the bootable content.
         /// </summary>
         public int BootContent { get; set; }
+
+        /// <summary>
+        /// Gets or sets the hash of the Content Info Records.
+        /// </summary>
+        public byte[] Hash { get; set; }
+
+        /// <summary>
+        /// Gets a collection of content info records.
+        /// </summary>
+        public Collection<ContentInfoRecord> InfoRecords { get; private set; }
 
         /// <summary>
         /// Gets a collection of content chunks.

--- a/src/Lemon/Titles/TitleMetadata.cs
+++ b/src/Lemon/Titles/TitleMetadata.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 SceneGate
+﻿// Copyright (c) 2020 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -34,6 +34,16 @@ namespace SceneGate.Lemon.Titles
         {
             Chunks = new Collection<ContentChunkRecord>();
         }
+
+        /// <summary>
+        /// Gets or sets the signature type.
+        /// </summary>
+        public uint SignType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the signature size.
+        /// </summary>
+        public int SignSize { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the title metadata has a

--- a/src/Lemon/Titles/TitleMetadata2Binary.cs
+++ b/src/Lemon/Titles/TitleMetadata2Binary.cs
@@ -1,0 +1,99 @@
+﻿// TitleMetadata2Binary.cs
+//
+// Author:
+//       Maxwell Ruiz maxwellaquaruiz@gmail.com
+//
+// Copyright (c) 2022 Maxwell Ruiz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+namespace SceneGate.Lemon.Titles
+{
+    using System;
+    using Yarhl.FileFormat;
+    using Yarhl.IO;
+
+    /// <summary>
+    /// Convert a TitleMetadata instance into binary format.
+    /// </summary>
+    public class TitleMetadata2Binary : IConverter<TitleMetadata, BinaryFormat>
+    {
+        /// <summary>
+        /// Converts a binary format into a title metadata object.
+        /// </summary>
+        /// <param name="source">The source binary.</param>
+        /// <returns>The deserializer title metadata.</returns>
+        public BinaryFormat Convert(TitleMetadata source)
+        {
+            var binary = new BinaryFormat();
+            var writer = new DataWriter(binary.Stream) {
+                Endianness = EndiannessMode.BigEndian,
+            };
+
+            writer.Write(source.SignType);
+            writer.Write(source.Signature);
+            writer.Write(source.SignatureIssuer.PadRight(0x40, '\0'));
+            writer.Write(source.Version);
+            writer.Write(source.CaCrlVersion);
+            writer.Write(source.SignerCrlVersion);
+            writer.Write((byte)0x0); // Reserved
+
+            writer.Write(source.SystemVersion);
+            writer.Write(source.TitleId);
+            writer.Write(source.TitleType);
+            writer.Write(source.GroupId);
+            writer.Write(source.SaveSize);
+            writer.Write(source.SrlPrivateSaveSize);
+            writer.Write(new byte[0x4]); // Reserved
+
+            writer.Write(source.SrlFlag);
+            writer.Write(new byte[0x31]); // Reserved
+
+            writer.Write(source.AccessRights);
+            writer.Write(source.TitleVersion);
+            writer.Write((short)source.Chunks.Count);
+            writer.Write((short)source.BootContent);
+            writer.Write(new byte[0x2]); // Padding
+
+            writer.Write(source.Hash);
+
+            for (int i = 0; i < source.InfoRecords.Count; i++) {
+                var infoRecord = source.InfoRecords[i];
+
+                writer.Write(infoRecord.IndexOffset);
+                writer.Write(infoRecord.CommandCount);
+                writer.Write(infoRecord.Hash);
+            }
+
+            for (int i = 0; i < source.Chunks.Count; i++) {
+                var chunk = source.Chunks[i];
+
+                writer.Write(chunk.Id);
+                writer.Write(chunk.Index);
+
+                int attribute = (int)Enum.Parse(typeof(ContentAttributes), chunk.Attributes.ToString());
+                writer.Write((short)attribute);
+
+                writer.Write(chunk.Size);
+                writer.Write(chunk.Hash);
+            }
+
+            return binary;
+        }
+    }
+}

--- a/src/Lemon/Titles/TitleMetadata2Binary.cs
+++ b/src/Lemon/Titles/TitleMetadata2Binary.cs
@@ -29,12 +29,12 @@ namespace SceneGate.Lemon.Titles
     using Yarhl.IO;
 
     /// <summary>
-    /// Convert a TitleMetadata instance into binary format.
+    /// Convert a TitleMetadata object into binary format.
     /// </summary>
     public class TitleMetadata2Binary : IConverter<TitleMetadata, BinaryFormat>
     {
         /// <summary>
-        /// Converts a binary format into a title metadata object.
+        /// Converts a title metadata object into a binary format.
         /// </summary>
         /// <param name="source">The source binary.</param>
         /// <returns>The deserializer title metadata.</returns>


### PR DESCRIPTION
### Description

When generating a new CIA using `NodeContainer2BinaryCia`, it will now update the TMD and later convert it to binary using `TitleMetadata2Binary`. Also added class `ContentInfoRecord` to help this.
Tested generating a modified CIA for Phoenix Wright: Ace Attorney Trilogy, which installs correctly on real hardware (Old 3DS).

### Example

```cs
nodeContainer.TransformWith<NodeContainer2BinaryCia>();
```

This closes #13 and closes #14 
